### PR TITLE
ci: add Strix security scanning for Chronos

### DIFF
--- a/.github/workflows/strix-security.yml
+++ b/.github/workflows/strix-security.yml
@@ -1,0 +1,75 @@
+name: Strix Security Scan
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  strix-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require Strix secrets
+        env:
+          STRIX_LLM: ${{ secrets.STRIX_LLM }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          if [ -z "$STRIX_LLM" ] || [ -z "$LLM_API_KEY" ]; then
+            echo "::error::Missing repository secrets STRIX_LLM and/or LLM_API_KEY."
+            echo "Add them under Settings → Secrets and variables → Actions, then re-run."
+            echo "Example STRIX_LLM value: openai/gpt-5.4"
+            exit 1
+          fi
+
+      - name: Install Strix
+        run: curl -sSL https://strix.ai/install | bash
+
+      - name: Run Strix (quick, PR diff-scoped)
+        env:
+          STRIX_LLM: ${{ secrets.STRIX_LLM }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          export PATH="$HOME/.strix/bin:$PATH"
+          BASE_REF="${{ github.base_ref }}"
+          if [ -z "$BASE_REF" ]; then
+            BASE_REF="main"
+          fi
+          strix -n -t ./ \
+            --scan-mode quick \
+            --scope-mode auto \
+            --diff-base "origin/${BASE_REF}" \
+            --max-budget 10 \
+            --instruction "White-box security review of Chronos (Node.js/TypeScript DST framework). Focus on supply-chain risks, unsafe deserialization of Trace/capsule JSON, CLI command injection, path traversal in inspector/trace loading, prototype pollution, and accidental entropy/network exposure. Do not attack third-party systems."
+
+      - name: Fail unless the scan completed
+        if: always() && hashFiles('strix_runs/**/run.json') != ''
+        run: |
+          run_json=$(ls -t strix_runs/*/run.json | head -1)
+          status=$(jq -r .status "$run_json")
+          echo "Strix run status: $status"
+          if [ "$status" != "completed" ]; then
+            echo "Strix run status is '$status' — scan did not complete (likely budget exhausted)." >&2
+            exit 1
+          fi
+
+      - name: Upload SARIF
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: strix_runs
+
+      - name: Upload Strix artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: strix-scan-results
+          path: strix_runs/
+          if-no-files-found: ignore

--- a/.github/workflows/strix-security.yml
+++ b/.github/workflows/strix-security.yml
@@ -16,22 +16,26 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Require Strix secrets
+      - name: Check Strix secrets
+        id: secrets
         env:
           STRIX_LLM: ${{ secrets.STRIX_LLM }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           if [ -z "$STRIX_LLM" ] || [ -z "$LLM_API_KEY" ]; then
-            echo "::error::Missing repository secrets STRIX_LLM and/or LLM_API_KEY."
-            echo "Add them under Settings → Secrets and variables → Actions, then re-run."
-            echo "Example STRIX_LLM value: openai/gpt-5.4"
-            exit 1
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Strix scan — add repository secrets STRIX_LLM and LLM_API_KEY, then re-run."
+            echo "Example STRIX_LLM: openai/gpt-5.4"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install Strix
+        if: steps.secrets.outputs.configured == 'true'
         run: curl -sSL https://strix.ai/install | bash
 
       - name: Run Strix (quick, PR diff-scoped)
+        if: steps.secrets.outputs.configured == 'true'
         env:
           STRIX_LLM: ${{ secrets.STRIX_LLM }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
@@ -49,7 +53,7 @@ jobs:
             --instruction "White-box security review of Chronos (Node.js/TypeScript DST framework). Focus on supply-chain risks, unsafe deserialization of Trace/capsule JSON, CLI command injection, path traversal in inspector/trace loading, prototype pollution, and accidental entropy/network exposure. Do not attack third-party systems."
 
       - name: Fail unless the scan completed
-        if: always() && hashFiles('strix_runs/**/run.json') != ''
+        if: steps.secrets.outputs.configured == 'true'
         run: |
           run_json=$(ls -t strix_runs/*/run.json | head -1)
           status=$(jq -r .status "$run_json")
@@ -60,14 +64,14 @@ jobs:
           fi
 
       - name: Upload SARIF
-        if: always()
+        if: steps.secrets.outputs.configured == 'true'
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: strix_runs
 
       - name: Upload Strix artifacts
-        if: always()
+        if: steps.secrets.outputs.configured == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: strix-scan-results

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ config.js
 .env.*.local
 .github-pages/
 
+
+# Strix scan artifacts
+strix_runs/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a GitHub Actions workflow that runs [Strix](https://github.com/usestrix/strix) (open-source AI pentesting) against Chronos on pull requests and via manual `workflow_dispatch`.

## What's included
- `.github/workflows/strix-security.yml` — headless `quick` scan with PR diff-scope, completion check, SARIF upload, and artifact upload
- Skips cleanly (no failed check) when `STRIX_LLM` / `LLM_API_KEY` secrets are not configured yet
- `.gitignore` — ignore `strix_runs/` scan artifacts

## Live scan status (cloud agent)
Strix **1.5.2** was installed and the sandbox image `ghcr.io/usestrix/strix-sandbox:1.3.0` was pulled successfully. A full scan could **not** be completed in this environment because:
1. No `LLM_API_KEY` / `STRIX_LLM` (or `STRIX_API_TOKEN` for app.strix.ai) is available to the agent
2. A local Ollama (`llama3.1:8b`) fallback was attempted; Strix abandoned turns after 300s with no stream events (CPU inference too slow for agent prompts)

**Result:** 0 validated findings (scan interrupted before analysis).

## Required to complete the scan
Add repository secrets, then re-run the workflow (Actions → Strix Security Scan → Run workflow), or reply with a key so the agent can finish:
- `STRIX_LLM` — e.g. `openai/gpt-5.4` or `anthropic/claude-sonnet-4-6`
- `LLM_API_KEY` — provider API key

Alternatively, create a token at [app.strix.ai](https://app.strix.ai) → Settings → API Access and use the managed cloud path (`STRIX_API_TOKEN`) with no local Docker/LLM.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8c33c69-4c60-4f11-8ce8-1d7519baf7dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8c33c69-4c60-4f11-8ce8-1d7519baf7dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

